### PR TITLE
implement builder entry point

### DIFF
--- a/src/AtomBuilder.php
+++ b/src/AtomBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom;
+
+use Geeshoe\Atom\Contract\BuilderInterface;
+use Geeshoe\Atom\Factory\EntryFactory;
+use Geeshoe\Atom\Factory\FeedFactory;
+use Geeshoe\Atom\Model\Atom;
+
+/**
+ * Class AtomBuilder
+ *
+ * @package Geeshoe\Atom
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class AtomBuilder implements BuilderInterface
+{
+    private Atom $atom;
+
+    /**
+     * AtomBuilder constructor.
+     *
+     * @param Atom|null $atom
+     */
+    public function __construct(Atom $atom = null)
+    {
+        if ($atom === null) {
+            $atom = new Atom();
+        }
+
+        $this->atom = $atom;
+    }
+
+    /**
+     * @@inheritDoc
+     */
+    public function getAtom(): Atom
+    {
+        return $this->atom;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createFeed(string $id, string $title, \DateTimeInterface $lastUpdated): void
+    {
+        $this->atom->setFeedElement(FeedFactory::createFeed($id, $title, $lastUpdated));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addEntry(string $id, string $title, \DateTimeInterface $lastUpdated): void
+    {
+        $this->atom->addEntryElement(EntryFactory::createEntry($id, $title, $lastUpdated));
+    }
+}

--- a/src/Contract/BuilderInterface.php
+++ b/src/Contract/BuilderInterface.php
@@ -54,4 +54,11 @@ interface BuilderInterface
      * @param \DateTimeInterface $lastUpdated
      */
     public function addEntry(string $id, string $title, \DateTimeInterface $lastUpdated): void;
+
+    /**
+     * Get Atom XML string
+     *
+     * @return string
+     */
+    public function publish(): string;
 }

--- a/src/Contract/BuilderInterface.php
+++ b/src/Contract/BuilderInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\Contract;
+
+use Geeshoe\Atom\Model\Atom;
+
+/**
+ * Interface BuilderInterface
+ *
+ * @package Geeshoe\Atom\Contract
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+interface BuilderInterface
+{
+    /**
+     * Get representation of all required Atom 1.0 elements
+     *
+     * @return Atom
+     */
+    public function getAtom(): Atom;
+
+    /**
+     * Create the Feed element required for Atom 1.0
+     *
+     * @param string             $id
+     * @param string             $title
+     * @param \DateTimeInterface $lastUpdated
+     */
+    public function createFeed(string $id, string $title, \DateTimeInterface $lastUpdated): void;
+
+    /**
+     * Add a entry element for a Atom 1.0 feed
+     *
+     * @param string             $id
+     * @param string             $title
+     * @param \DateTimeInterface $lastUpdated
+     */
+    public function addEntry(string $id, string $title, \DateTimeInterface $lastUpdated): void;
+}

--- a/src/Model/Atom.php
+++ b/src/Model/Atom.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\Model;
+
+use Geeshoe\Atom\Contract\EntryRequiredInterface;
+use Geeshoe\Atom\Contract\FeedRequiredInterface;
+use Geeshoe\Atom\Exception\ModelException;
+
+/**
+ * Class Atom
+ *
+ * @package Geeshoe\Atom\Model
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class Atom
+{
+    private FeedRequiredInterface $feedElement;
+
+    private array $entryElements = [];
+
+    /**
+     * @param FeedRequiredInterface $feed
+     */
+    public function setFeedElement(FeedRequiredInterface $feed): void
+    {
+        $this->feedElement = $feed;
+    }
+
+    /**
+     * @return FeedRequiredInterface
+     */
+    public function getFeedElement(): FeedRequiredInterface
+    {
+        if (isset($this->feedElement)) {
+            return $this->feedElement;
+        }
+
+        throw ModelException::emptyPropertyException('Feed');
+    }
+
+    /**
+     * @param EntryRequiredInterface $entryElement
+     */
+    public function addEntryElement(EntryRequiredInterface $entryElement): void
+    {
+        $this->entryElements[] = $entryElement;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntryElements(): array
+    {
+        return $this->entryElements;
+    }
+}

--- a/tests/UnitTests/AtomBuilderTest.php
+++ b/tests/UnitTests/AtomBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\UnitTests;
+
+use Geeshoe\Atom\AtomBuilder;
+use Geeshoe\Atom\Model\Atom;
+use Geeshoe\Atom\Model\Entry;
+use Geeshoe\Atom\Model\Feed;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AtomBuilderTest
+ *
+ * @package Geeshoe\Atom\UnitTests
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class AtomBuilderTest extends TestCase
+{
+    public function testConstructorCreatesAtomInstanceIfOneNotProvided(): void
+    {
+        $builder = new AtomBuilder();
+
+        $this->assertInstanceOf(Atom::class, $builder->getAtom());
+    }
+
+    public function testConstructorSetAtomInstanceProvidedAsParam(): void
+    {
+        $mockAtom = $this->createMock(Atom::class);
+
+        $builder = new AtomBuilder($mockAtom);
+
+        $this->assertSame($mockAtom, $builder->getAtom());
+    }
+
+    public function testCreateFeedCallsAtomSetFeedElementWithProvidedElementParams(): void
+    {
+        $mockAtom = $this->createMock(Atom::class);
+        $mockAtom->expects($this->once())
+            ->method('setFeedElement')
+            ->with(self::isInstanceOf(Feed::class))
+        ;
+
+        $mockTime = $this->createMock(\DateTime::class);
+
+        $builder = new AtomBuilder($mockAtom);
+        $builder->createFeed('testId', 'testTitle', $mockTime);
+    }
+
+    public function testAddEntryCallsAtomAddEntryElementWithEntryModel(): void
+    {
+        $mockAtom = $this->createMock(Atom::class);
+        $mockAtom->expects($this->once())
+            ->method('addEntryElement')
+            ->with(self::isInstanceOf(Entry::class))
+        ;
+
+        $mockTime = $this->createMock(\DateTime::class);
+
+        $builder = new AtomBuilder($mockAtom);
+        $builder->addEntry('testId', 'testTitle', $mockTime);
+    }
+}

--- a/tests/UnitTests/Contract/BuilderInterfaceTest.php
+++ b/tests/UnitTests/Contract/BuilderInterfaceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\UnitTests\Contract;
+
+use Geeshoe\Atom\Contract\BuilderInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BuilderInterfaceTest
+ *
+ * @package Geeshoe\Atom\UnitTests\Contract
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class BuilderInterfaceTest extends TestCase
+{
+    /**
+     * @return array<array>
+     */
+    public function requiredMethodDataProvider(): array
+    {
+        return [
+            ['createFeed'],
+            ['addEntry'],
+            ['publish']
+        ];
+    }
+
+    /**
+     * @dataProvider requiredMethodDataProvider
+     * @param string $methodName
+     */
+    public function testBuilderInterfaceDefinesRequiredMethods(string $methodName): void
+    {
+        self::assertTrue(method_exists(BuilderInterface::class, $methodName));
+    }
+}

--- a/tests/UnitTests/Model/AtomTest.php
+++ b/tests/UnitTests/Model/AtomTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\UnitTests\Model;
+
+use Geeshoe\Atom\Exception\ModelException;
+use Geeshoe\Atom\Model\Atom;
+use Geeshoe\Atom\Model\Entry;
+use Geeshoe\Atom\Model\Feed;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AtomTest
+ *
+ * @package Geeshoe\Atom\UnitTests\Model
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class AtomTest extends TestCase
+{
+    /**
+     * @return array<array>
+     */
+    public function requiredPropertyDataProvider(): array
+    {
+        return [
+            'FeedElement Property not found' => ['feedElement'],
+            'EntryElements Property not found' => ['entryElements']
+        ];
+    }
+
+    /**
+     * @dataProvider requiredPropertyDataProvider
+     * @param string $propertyName
+     */
+    public function testAtomHasRequiredProperties(string $propertyName): void
+    {
+        self::assertClassHasAttribute($propertyName, Atom::class);
+    }
+
+    public function testGetFeedElementThrowsModelExceptionIfFeedElementNotSet(): void
+    {
+        $this->expectException(ModelException::class);
+
+        $atom = new Atom();
+        $atom->getFeedElement();
+    }
+
+    public function testFeedElementGetterSetter(): void
+    {
+        $mockFeed = $this->createMock(Feed::class);
+
+        $atom = new Atom();
+        $atom->setFeedElement($mockFeed);
+
+        $this->assertSame($mockFeed, $atom->getFeedElement());
+    }
+
+    public function testEntryElementGetterAlwaysReturnsArray(): void
+    {
+        $atom = new Atom();
+
+        $this->assertSame([], $atom->getEntryElements());
+    }
+
+    public function testEntryElementsGetterSetter(): void
+    {
+        $mockEntry = $this->createMock(Entry::class);
+
+        $atom = new Atom();
+        $atom->addEntryElement($mockEntry);
+
+        $expected[] = $mockEntry;
+
+        $this->assertSame($expected, $atom->getEntryElements());
+    }
+}


### PR DESCRIPTION
AtomBuilder to provide entry point to generate RFC 5287 compliant Atom XML documents.

- [x] Ability to Add entry elements
- [ ] Ability to Edit entry elements
- [ ] Ability to Remove entry elements