### PR TITLE
implement ability to have element collections

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,7 @@ parameters:
             message: '#, PHPUnit\Framework\MockObject\MockObject|[a-zA-Z0-9\\_] given.#'
             paths:
                 - tests/UnitTests
+        -
+            message: '#Unable to resolve the template type ExpectedType in call to method static method.#'
+            paths:
+                - tests/UnitTests/Contract/CollectionInterfaceTest.php

--- a/src/Collection/ElementCollection.php
+++ b/src/Collection/ElementCollection.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\Collection;
+
+use Geeshoe\Atom\Contract\CollectionInterface;
+use Geeshoe\Atom\Contract\ElementInterface;
+
+/**
+ * Class ElementCollection
+ *
+ * @package Geeshoe\Atom\Collection
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ * @template-implements CollectionInterface<int|null, ElementInterface>
+ */
+class ElementCollection implements CollectionInterface
+{
+    /** @var array<ElementInterface> */
+    private array $elements = [];
+
+    public function add(ElementInterface $element): void
+    {
+        $this->elements[] = $element;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->elements[$offset]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetGet($offset)
+    {
+        return $this->elements[$offset];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if ($offset === null) {
+            $this->elements[] = $value;
+            return;
+        }
+
+        $this->elements[$offset] = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->elements[$offset]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->elements);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count(): int
+    {
+        return count($this->elements);
+    }
+}

--- a/src/Contract/CollectionInterface.php
+++ b/src/Contract/CollectionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\Contract;
+
+/**
+ * Interface CollectionInterface
+ *
+ * @package Geeshoe\Atom\Contract
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ * @template TKey
+ * @template T
+ * @template-extends \IteratorAggregate<TKey, T>
+ * @template-extends \ArrayAccess<TKey, T>
+ */
+interface CollectionInterface extends \ArrayAccess, \Countable, \IteratorAggregate
+{
+}

--- a/src/Contract/ElementInterface.php
+++ b/src/Contract/ElementInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\Contract;
+
+/**
+ * Interface ElementInterface
+ *
+ * @package Geeshoe\Atom\Contract
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+interface ElementInterface
+{
+}

--- a/tests/UnitTests/Collection/ElementCollectionTest.php
+++ b/tests/UnitTests/Collection/ElementCollectionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\UnitTests\Collection;
+
+use Geeshoe\Atom\Collection\ElementCollection;
+use Geeshoe\Atom\Contract\CollectionInterface;
+use Geeshoe\Atom\Contract\ElementInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ElementCollectionTest
+ *
+ * @package Geeshoe\Atom\UnitTests\Collection
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class ElementCollectionTest extends TestCase
+{
+    protected ?MockObject $mockElementInterface;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->mockElementInterface = $this->createMock(ElementInterface::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        $this->mockElementInterface = null;
+    }
+
+    public function testElementCollectionImplementsCollectionInterface(): void
+    {
+        self::assertInstanceOf(CollectionInterface::class, new ElementCollection());
+    }
+
+    public function testElementCollectionHasElementProperty(): void
+    {
+        self::assertClassHasAttribute('elements', ElementCollection::class);
+    }
+
+    public function interfaceMethodDataProvider(): \Generator
+    {
+        yield ['offsetExists'];
+        yield ['offsetGet'];
+        yield ['offsetSet'];
+        yield ['offsetUnset'];
+        yield ['count'];
+        yield ['getIterator'];
+    }
+
+    /**
+     * @dataProvider interfaceMethodDataProvider
+     */
+    public function testElementCollectionImplementsInterfaceMethods(string $methodName): void
+    {
+        self::assertTrue(method_exists(ElementCollection::class, $methodName));
+    }
+
+    public function testAddMethodAddsElementInterfaceToCollection(): void
+    {
+        $collection = new ElementCollection();
+        $collection->add($this->mockElementInterface);
+
+        self::assertSame($this->mockElementInterface, $collection[0]);
+    }
+
+    public function testCountReturnsCountOfElementsProperty(): void
+    {
+        $collection = new ElementCollection();
+        $collection->add($this->mockElementInterface);
+        $collection->add($this->mockElementInterface);
+
+        self::assertSame(2, $collection->count());
+    }
+
+    public function testGetIteratorProvidesArrayIteratorForElementProperty(): void
+    {
+        $collection = new ElementCollection();
+        $collection->add($this->mockElementInterface);
+
+        $result = $collection->getIterator();
+
+        $this->assertInstanceOf(\ArrayIterator::class, $result);
+        self::assertCount(1, $result);
+    }
+
+    public function testOffsetExistsReturnsBoolIfElementsPropertyKeyExists(): void
+    {
+        $collection = new ElementCollection();
+
+        self::assertFalse($collection->offsetExists(0));
+        $collection->add($this->mockElementInterface);
+        self::assertTrue($collection->offsetExists(0));
+    }
+
+    public function testOffsetGetReturnsElementFromElementsPropertyAtGivenKey(): void
+    {
+        $collection = new ElementCollection();
+        $collection->add($this->mockElementInterface);
+
+        self::assertSame($this->mockElementInterface, $collection->offsetGet(0));
+    }
+
+    public function testOffsetSetAddsElementToElementsPropertyWithNullKey(): void
+    {
+        $collection = new ElementCollection();
+        $collection->offsetSet(null, $this->mockElementInterface);
+
+        self::assertArrayHasKey(0, $collection);
+    }
+
+    public function testOffsetSetAddsElementToElementsPropertyWithKey(): void
+    {
+        $collection = new ElementCollection();
+        $collection->offsetSet('test', $this->mockElementInterface);
+
+        self::assertArrayHasKey('test', $collection);
+    }
+
+    public function testOffsetUnsetRemovesElementFromElementsPropertyWithProvidedKey(): void
+    {
+        $collection = new ElementCollection();
+        $collection[5] = $this->mockElementInterface;
+
+        self::assertCount(1, $collection);
+
+        $collection->offsetUnset(5);
+        self::assertCount(0, $collection);
+    }
+}

--- a/tests/UnitTests/Contract/CollectionInterfaceTest.php
+++ b/tests/UnitTests/Contract/CollectionInterfaceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright 2020 Jesse Rushlow - Geeshoe Development
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Geeshoe\Atom\UnitTests\Contract;
+
+use Geeshoe\Atom\Contract\CollectionInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class CollectionInterfaceTest
+ *
+ * @package Geeshoe\Atom\UnitTests\Contract
+ * @author  Jesse Rushlow <jr@geeshoe.com>
+ */
+class CollectionInterfaceTest extends TestCase
+{
+    public function interfaceDateProvider(): array
+    {
+        return [
+            [\ArrayAccess::class],
+            [\Countable::class],
+            [\IteratorAggregate::class]
+        ];
+    }
+
+    /**
+     * @dataProvider interfaceDateProvider
+     */
+    public function testCollectionInterfaceExtendsInterfaces(string $interfaceSignature): void
+    {
+        $collection = $this->createMock(CollectionInterface::class);
+
+        self::assertInstanceOf($interfaceSignature, $collection);
+    }
+}


### PR DESCRIPTION
Created a collection interface for element objects to implements. `ElementCollection::class` only accepts `ElementInterface` objects within the collection.

partially implements issue #27 _Atom::entryElements should be a collection rather than simple array_