### PR TITLE
implement feed element id

### DIFF
--- a/src/Generator/FeedGenerator.php
+++ b/src/Generator/FeedGenerator.php
@@ -42,9 +42,14 @@ class FeedGenerator
 
     public function createFeedElement(): \DOMElement
     {
-        return $this->dom->createElementNS(
+        $feed = $this->dom->createElementNS(
             'http://www.w3.org/2005/Atom',
             'feed'
         );
+
+        $feed->setAttribute('id', 'feed');
+
+        $feed->setIdAttribute('id', true);
+        return $feed;
     }
 }

--- a/src/Generator/XMLGenerator.php
+++ b/src/Generator/XMLGenerator.php
@@ -86,9 +86,8 @@ class XMLGenerator implements GeneratorInterface
     public function addEntry(EntryInterface $entry): void
     {
         $entryNode = $this->createEntryElement($entry);
-        $nodeList = $this->document->getElementsByTagName('feed');
 
-        $feed = $nodeList->item(0);
+        $feed = $this->document->getElementById('feed');
         $feed->appendChild($entryNode);
     }
 

--- a/tests/FunctionalTests/Generator/XMLGeneratorTest.php
+++ b/tests/FunctionalTests/Generator/XMLGeneratorTest.php
@@ -64,14 +64,14 @@ class XMLGeneratorTest extends TestCase
     {
         $notPretty = <<<'EOT'
             <?xml version="1.0" encoding="UTF-8"?>
-            <feed xmlns="http://www.w3.org/2005/Atom"><id>http://geeshoe.com/</id>
+            <feed xmlns="http://www.w3.org/2005/Atom" id="feed"><id>http://geeshoe.com/</id>
             EOT;
 
         $notPretty .= '<title>Functional Title</title><updated>2019-12-31T18:30:02+00:00</updated></feed>' . "\n";
 
         $pretty = <<<'EOT'
             <?xml version="1.0" encoding="UTF-8"?>
-            <feed xmlns="http://www.w3.org/2005/Atom">
+            <feed xmlns="http://www.w3.org/2005/Atom" id="feed">
               <id>http://geeshoe.com/</id>
               <title>Functional Title</title>
               <updated>2019-12-31T18:30:02+00:00</updated>

--- a/tests/UnitTests/Generator/XMLGeneratorTest.php
+++ b/tests/UnitTests/Generator/XMLGeneratorTest.php
@@ -177,25 +177,18 @@ class XMLGeneratorTest extends TestCase
     {
         $this->setExpectationsForCreateEntryNode();
 
-        $mockNodeList = $this->createMock(\DOMNodeList::class);
-        $mockNodeList
-            ->expects($this->once())
-            ->method('item')
-            ->with(0)
-            ->willReturn($this->mockNode)
-        ;
-
-        $this->mockNode
+        $mockFeedElement = $this->createMock(\DOMElement::class);
+        $mockFeedElement
             ->expects($this->once())
             ->method('appendChild')
-            ->with(self::isInstanceOf(\DOMNode::class))
+            ->with(self::isInstanceOf(\DOMElement::class))
         ;
 
         $this->mockDocument
             ->expects($this->once())
-            ->method('getElementsByTagName')
+            ->method('getElementById')
             ->with('feed')
-            ->willReturn($mockNodeList)
+            ->willReturn($mockFeedElement)
         ;
 
         $generator = new XMLGenerator($this->mockDocument);


### PR DESCRIPTION
refs issue #32 _XMLGenerator::addEntry() get feed by xml id instead of tag_
fixes issue #33 _null pointer exception possible in XMLGenerator::addEntry()_