### PR TITLE
bump minimum php to 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           composer-options: "--prefer-dist --no-progress"
 
       - name: Unit Tests
-        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
+        run: vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
 
       - name: Functional Tests
-        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional
+        run: vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,41 @@
-name: Atom CI
-on: [push, pull_request]
+name: PHPUnit
+on:
+  push:
+    branches: ['main']
+  pull_request:
+  schedule:
+    - cron: '0 */12 * * *'
+
 jobs:
-  atom:
-    name: Atom
+  tests:
+    name: "${{ matrix.php-version }} ${{ matrix.dependency-versions }}"
     runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        # normal, highest, non-dev installs
+        php-version: ['8.1', '8.2']
+        composer-options: ['--prefer-stable']
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.0.0
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
 
-      - name: Validate Composer .json and .lock
-        run: composer validate
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+      - name: "Composer install"
+        uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          composer-options: "--prefer-dist --no-progress"
 
-      - name: Psalm Static Analysis
-        run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml --diff --diff-format=udiff --dry-run
-        if: always()
-        continue-on-error: true
+      - name: Unit Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
 
-      - name: PHPStan
-        run: vendor/bin/phpstan analyze -c $GITHUB_WORKSPACE/phpstan.neon
-        if: always()
-        continue-on-error: true
-
-      - name: PHPUnit
-        run: vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --coverage-text
-        if: always()
+      - name: Functional Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -13,59 +13,40 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   name: Set PHP Version
-                run: sudo update-alternatives --set php /usr/bin/php8.0
-
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Validate
                 run: composer validate --strict
 
     php-cs-fixer:
-        name: Lint PHP Source
+        name: PHP-CS-Fixer
         runs-on: ubuntu-latest
 
         steps:
-            -   name: Set PHP Version
-                run: sudo update-alternatives --set php /usr/bin/php8.0
-
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
-            -   name: Install PHP-CS-Fixer
-                run: composer install -d $GITHUB_WORKSPACE/tools/php-cs-fixer --prefer-dist --no-progress
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+                    tools: php-cs-fixer
 
-            -   name: Enforce coding standards
-                run: $GITHUB_WORKSPACE/tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/tools/php-cs-fixer/.php-cs-fixer.dist.php --dry-run --allow-risky=yes
-
-#    psalm:
-#        name: Psalm Static Analysis
-#        runs-on: ubuntu-latest
-#
-#        steps:
-#            -   name: Set PHP Version
-#                run: sudo update-alternatives --set php /usr/bin/php8.0
-#
-#            -   name: Checkout
-#                uses: actions/checkout@v2
-#
-#            -   name: Install Dependencies
-#                run: composer install --prefer-dist --no-progress
-#
-#            -   name: Analyze Source
-#                run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
-#
+            -   name: Run PHP-CS-Fixer
+                run: php-cs-fixer fix --dry-run --diff
     rector:
         name: Rector PHP Source
         runs-on: ubuntu-latest
 
         steps:
-            -   name: Set PHP Version
-                run: sudo update-alternatives --set php /usr/bin/php8.0
-
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
 
             -   name: Install Dependencies
                 run: composer install -d $GITHUB_WORKSPACE/tools/rector --prefer-dist --no-progress

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,8 +1,13 @@
 <?php
 
+if (!file_exists(__DIR__.'/src') || !file_exists(__DIR__.'/tests')) {
+    exit(0);
+}
+
 $finder = (new PhpCsFixer\Finder())
-    ->in(dirname(__DIR__, 2))
+    ->in([__DIR__.'/src', __DIR__.'/tests'])
 ;
+
 
 $copyright = <<< 'EOT'
 Copyright 2020 Jesse Rushlow - Rushlow Development.

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,7 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
-    "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^1.2",
-    "phpstan/extension-installer": "^1.1",
-    "phpstan/phpstan-phpunit": "^1.0",
-    "vimeo/psalm": "^4.14",
-    "psalm/plugin-phpunit": "^0.16.1"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "league/uri": "^6.0"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,10 @@
         backupStaticAttributes="true"
 >
     <testsuites>
-        <testsuite name="UnitTests">
+        <testsuite name="unit">
             <directory>tests/UnitTests</directory>
         </testsuite>
-        <testsuite name="FunctionalTests">
+        <testsuite name="functional">
             <directory>tests/FunctionalTests</directory>
         </testsuite>
     </testsuites>

--- a/src/Contract/CollectionInterface.php
+++ b/src/Contract/CollectionInterface.php
@@ -20,8 +20,10 @@ namespace RushlowDevelopment\Atom\Contract;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
+ *
  * @template TKey
  * @template T
+ *
  * @template-extends \IteratorAggregate<TKey, T>
  * @template-extends \ArrayAccess<TKey, T>
  */

--- a/tests/FunctionalTests/Generator/XMLGeneratorTest.php
+++ b/tests/FunctionalTests/Generator/XMLGeneratorTest.php
@@ -106,7 +106,7 @@ class XMLGeneratorTest extends TestCase
 
         $result = $generator->generate();
 
-        //@TODO Refactor with a more elegant solution
+        // @TODO Refactor with a more elegant solution
         $xml = $this->xmlResultDataProvider();
         $entryXML = '<entry><id>https://geeshoe.com</id><title>Entry Title 1</title>'
             .'<updated>2019-12-31T18:30:02+00:00</updated></entry>';


### PR DESCRIPTION
- Bumps PHP Version to `8.1`
- static analysis tools are no longer dev dependencies
- updates CI config accordingly