### PR TITLE
add author(s) to the feed and entries

### DIFF
--- a/src/AtomBuilder.php
+++ b/src/AtomBuilder.php
@@ -18,11 +18,13 @@
 
 namespace RushlowDevelopment\Atom;
 
+use RushlowDevelopment\Atom\Collection\PersonCollection;
 use RushlowDevelopment\Atom\Generator\AtomXmlGenerator;
 use RushlowDevelopment\Atom\Model\Atom;
 use RushlowDevelopment\Atom\Model\Entry;
 use RushlowDevelopment\Atom\Model\Feed;
 use RushlowDevelopment\Atom\Model\Link;
+use RushlowDevelopment\Atom\Model\Person;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -41,6 +43,7 @@ final class AtomBuilder
         \DateTimeInterface $lastUpdated,
          null|Link $link = null,
         null|string $subtitle = null,
+        null|Person|PersonCollection $author = null,
     ): self {
         $feed = new Feed($id, $title, $lastUpdated);
 
@@ -50,6 +53,10 @@ final class AtomBuilder
 
         if (null !== $subtitle) {
             $feed->setSubtitle($subtitle);
+        }
+
+        if (null !== $author) {
+            $feed->setAuthor($author);
         }
 
         $atom = (new Atom())->setFeedElement($feed);

--- a/src/Collection/AbstractCollection.php
+++ b/src/Collection/AbstractCollection.php
@@ -54,7 +54,7 @@ abstract class AbstractCollection implements CollectionInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->elements[$offset];
     }

--- a/src/Generator/AtomXmlGenerator.php
+++ b/src/Generator/AtomXmlGenerator.php
@@ -64,6 +64,12 @@ final class AtomXmlGenerator
             if (null !== $subtitle = $feedModel->getSubtitle()) {
                 $feedElement->appendChild(new \DOMElement('subtitle', $subtitle));
             }
+
+            foreach ($feedModel->getAuthor() as $author) {
+                $authorElement = $this->document->createElement('author');
+                $authorElement->appendChild(new \DOMElement('name', $author->getName()));
+                $feedElement->appendChild($authorElement);
+            }
         } catch (\DOMException $exception) {
             throw new \RuntimeException('Unable to build feed element.', previous: $exception);
         }
@@ -96,6 +102,12 @@ final class AtomXmlGenerator
                     $element->appendChild($text);
 
                     $node->appendChild($element);
+                }
+
+                foreach ($entry->getAuthor() as $author) {
+                    $authorElement = $this->document->createElement('author');
+                    $authorElement->appendChild(new \DOMElement('name', $author->getName()));
+                    $node->appendChild($authorElement);
                 }
             } catch (\DOMException $exception) {
                 throw new \RuntimeException('Unable to build feed element.', previous: $exception);

--- a/src/Model/Atom.php
+++ b/src/Model/Atom.php
@@ -18,8 +18,6 @@
 
 namespace RushlowDevelopment\Atom\Model;
 
-use RushlowDevelopment\Atom\Contract\EntryInterface;
-use RushlowDevelopment\Atom\Contract\FeedInterface;
 use RushlowDevelopment\Atom\Exception\ModelException;
 
 /**
@@ -27,19 +25,19 @@ use RushlowDevelopment\Atom\Exception\ModelException;
  */
 final class Atom
 {
-    private FeedInterface $feedElement;
+    private Feed $feedElement;
 
-    /** @var EntryInterface[] */
+    /** @var Entry[] */
     private array $entryElements = [];
 
-    public function setFeedElement(FeedInterface $feed): self
+    public function setFeedElement(Feed $feed): self
     {
         $this->feedElement = $feed;
 
         return $this;
     }
 
-    public function getFeedElement(): FeedInterface
+    public function getFeedElement(): Feed
     {
         if (isset($this->feedElement)) {
             return $this->feedElement;
@@ -48,7 +46,7 @@ final class Atom
         throw ModelException::emptyPropertyException('Feed');
     }
 
-    public function addEntryElement(EntryInterface $entryElement): self
+    public function addEntryElement(Entry $entryElement): self
     {
         $this->entryElements[] = $entryElement;
 

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -95,9 +95,15 @@ final class Entry implements EntryInterface
         return $this->author;
     }
 
-    public function setAuthor(PersonCollection $author): void
+    public function setAuthor(Person|PersonCollection $author): self
     {
-        $this->author = $author;
+        if ($author instanceof PersonCollection) {
+            $this->author = $author;
+        } else {
+            $this->author->addPerson($author);
+        }
+
+        return $this;
     }
 
     public function getContent(): ?Content
@@ -105,9 +111,11 @@ final class Entry implements EntryInterface
         return $this->content;
     }
 
-    public function setContent(?Content $content): void
+    public function setContent(?Content $content): self
     {
         $this->content = $content;
+
+        return $this;
     }
 
     public function getLink(): ?Link

--- a/src/Model/Feed.php
+++ b/src/Model/Feed.php
@@ -29,7 +29,7 @@ use RushlowDevelopment\Atom\Exception\ModelException;
 final class Feed implements FeedInterface
 {
     // Recommended Optional Elements
-    private ?PersonCollection $author = null;
+    private PersonCollection $author;
     private ?Link $link = null;
 
     // Optional
@@ -51,6 +51,7 @@ final class Feed implements FeedInterface
         private string $title,
         private \DateTimeInterface $updated
     ) {
+        $this->author = new PersonCollection();
     }
 
     /**
@@ -89,14 +90,20 @@ final class Feed implements FeedInterface
         return $this->updated;
     }
 
-    public function getAuthor(): ?PersonCollection
+    public function getAuthor(): PersonCollection
     {
         return $this->author;
     }
 
-    public function setAuthor(PersonCollection $author): void
+    public function setAuthor(Person|PersonCollection $author): self
     {
-        $this->author = $author;
+        if ($author instanceof PersonCollection) {
+            $this->author = $author;
+        } else {
+            $this->author->addPerson($author);
+        }
+
+        return $this;
     }
 
     public function getCategory(): ?CategoryCollection

--- a/src/Validator/ElementValidator.php
+++ b/src/Validator/ElementValidator.php
@@ -24,8 +24,10 @@ use RushlowDevelopment\Atom\Exception\ValidatorException;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
  */
-class ElementValidator
+final class ElementValidator
 {
     /**
      * Return true if ID is a valid URI/IRI.

--- a/src/Validator/FeedValidator.php
+++ b/src/Validator/FeedValidator.php
@@ -20,7 +20,12 @@ namespace RushlowDevelopment\Atom\Validator;
 
 use RushlowDevelopment\Atom\Model\Atom;
 
-class FeedValidator
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class FeedValidator
 {
     public static function hasRequiredAuthors(Atom $atom): bool
     {

--- a/src/Validator/FeedValidator.php
+++ b/src/Validator/FeedValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2020 Jesse Rushlow - Rushlow Development.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace RushlowDevelopment\Atom\Validator;
+
+use RushlowDevelopment\Atom\Model\Atom;
+
+class FeedValidator
+{
+    public static function hasRequiredAuthors(Atom $atom): bool
+    {
+        // If a feed has an author element, the feed is valid.
+        if (\count($atom->getFeedElement()->getAuthor()) > 0) {
+            return true;
+        }
+
+        if (0 === \count($atom->getEntryElements())) {
+            return false;
+        }
+
+        // Entry authors are only required if the Feed DOES NOT have an author
+        foreach ($atom->getEntryElements() as $entry) {
+            if (0 === \count($entry->getAuthor())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/FunctionalTests/AtomBuilderTest.php
+++ b/tests/FunctionalTests/AtomBuilderTest.php
@@ -23,6 +23,7 @@ use RushlowDevelopment\Atom\AtomBuilder;
 use RushlowDevelopment\Atom\Model\Content;
 use RushlowDevelopment\Atom\Model\Entry;
 use RushlowDevelopment\Atom\Model\Link;
+use RushlowDevelopment\Atom\Model\Person;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -43,7 +44,8 @@ final class AtomBuilderTest extends TestCase
             title: 'Rushlow.dev XMLGenerator Test',
             lastUpdated: new \DateTimeImmutable('2023-01-17T23:00:00+00:00'),
             link: new Link('https://rushlow.dev/feed'),
-            subtitle: 'XMLGenerator Feed Test'
+            subtitle: 'XMLGenerator Feed Test',
+            author: new Person('Jesse Rushlow')
         );
 
         self::assertSame($this->getExpectedXml('feed-no-entries.xml'), $builder->generate());
@@ -57,8 +59,10 @@ final class AtomBuilderTest extends TestCase
             lastUpdated: new \DateTimeImmutable('2023-01-17T23:00:00+00:00')
         );
 
-        $entry = new Entry('https://rushlow.dev/some-link', 'Entry Test Title', new \DateTimeImmutable('2023-01-20T23:00:00+00:00'));
-        $entry->setContent(new Content('<p>Howdy!</p>', Content::TYPE_HTML));
+        $entry = (new Entry('https://rushlow.dev/some-link', 'Entry Test Title', new \DateTimeImmutable('2023-01-20T23:00:00+00:00')))
+            ->setContent(new Content('<p>Howdy!</p>', Content::TYPE_HTML))
+            ->setAuthor(new Person('Jesse Rushlow'))
+        ;
 
         $builder->addEntry($entry);
 

--- a/tests/FunctionalTests/AtomBuilderTest.php
+++ b/tests/FunctionalTests/AtomBuilderTest.php
@@ -69,6 +69,21 @@ final class AtomBuilderTest extends TestCase
         self::assertSame($this->getExpectedXml('feed-with-entry.xml'), $builder->generate());
     }
 
+    public function testExceptionThrownIfMissingAuthors(): void
+    {
+        $builder = AtomBuilder::createFeed('id', 'title', new \DateTimeImmutable());
+        $builder->setValidateFeed(false);
+
+        // No exception should be thrown.
+        $builder->generate();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Feed is not compliant with Atom 1.0 Specification - Missing Author(s) in either the atom:feed or atom:entry.');
+
+        $builder->setValidateFeed(true);
+        $builder->generate();
+    }
+
     private function getExpectedXml(string $filename): string
     {
         return file_get_contents(sprintf('%s/Fixture/expected/%s', __DIR__, $filename));

--- a/tests/FunctionalTests/Fixture/expected/feed-no-entries.xml
+++ b/tests/FunctionalTests/Fixture/expected/feed-no-entries.xml
@@ -5,4 +5,7 @@
   <updated>2023-01-17T23:00:00+00:00</updated>
   <link href="https://rushlow.dev/feed" rel="self"/>
   <subtitle>XMLGenerator Feed Test</subtitle>
+  <author>
+    <name>Jesse Rushlow</name>
+  </author>
 </feed>

--- a/tests/FunctionalTests/Fixture/expected/feed-with-entry.xml
+++ b/tests/FunctionalTests/Fixture/expected/feed-with-entry.xml
@@ -8,5 +8,8 @@
     <title>Entry Test Title</title>
     <updated>2023-01-20T23:00:00+00:00</updated>
     <content type="html">&lt;p&gt;Howdy!&lt;/p&gt;</content>
+    <author>
+      <name>Jesse Rushlow</name>
+    </author>
   </entry>
 </feed>

--- a/tests/FunctionalTests/Generator/AtomXmlGeneratorTest.php
+++ b/tests/FunctionalTests/Generator/AtomXmlGeneratorTest.php
@@ -24,6 +24,7 @@ use RushlowDevelopment\Atom\Model\Content;
 use RushlowDevelopment\Atom\Model\Entry;
 use RushlowDevelopment\Atom\Model\Feed;
 use RushlowDevelopment\Atom\Model\Link;
+use RushlowDevelopment\Atom\Model\Person;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -59,6 +60,7 @@ final class AtomXmlGeneratorTest extends TestCase
         $this->feedFixture
             ->setSubtitle('XMLGenerator Feed Test')
             ->setLink(new Link('https://rushlow.dev/feed'))
+            ->setAuthor(new Person('Jesse Rushlow'))
         ;
 
         $this->generator->buildFeedElement($this->feedFixture);
@@ -72,8 +74,10 @@ final class AtomXmlGeneratorTest extends TestCase
 
     public function testFeedWithEntries(): void
     {
-        $entry = new Entry('https://rushlow.dev/some-link', 'Entry Test Title', new \DateTimeImmutable('2023-01-20T23:00:00+00:00'));
-        $entry->setContent(new Content('<p>Howdy!</p>', Content::TYPE_HTML));
+        $entry = (new Entry('https://rushlow.dev/some-link', 'Entry Test Title', new \DateTimeImmutable('2023-01-20T23:00:00+00:00')))
+            ->setContent(new Content('<p>Howdy!</p>', Content::TYPE_HTML))
+            ->setAuthor(new Person('Jesse Rushlow'))
+        ;
 
         $this->generator->buildFeedElement($this->feedFixture);
         $this->generator->addEntriesToFeedElement([$entry]);

--- a/tests/UnitTests/Validator/FeedValidatorTest.php
+++ b/tests/UnitTests/Validator/FeedValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright 2020 Jesse Rushlow - Rushlow Development.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace RushlowDevelopment\Atom\UnitTests\Validator;
+
+use PHPUnit\Framework\TestCase;
+use RushlowDevelopment\Atom\Model\Atom;
+use RushlowDevelopment\Atom\Model\Entry;
+use RushlowDevelopment\Atom\Model\Feed;
+use RushlowDevelopment\Atom\Model\Person;
+use RushlowDevelopment\Atom\Validator\FeedValidator;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+final class FeedValidatorTest extends TestCase
+{
+    public function testAuthorRequirement(): void
+    {
+        $atom = new Atom();
+        $atom->setFeedElement($feed = new Feed('id', 'test', new \DateTimeImmutable()));
+
+        self::assertFalse(FeedValidator::hasRequiredAuthors($atom), 'Feed does not have an author. (No Entries)');
+
+        $feed->setAuthor(new Person('Jesse Rushlow'));
+
+        self::assertTrue(FeedValidator::hasRequiredAuthors($atom), 'Feed has an author. (No Entries)');
+
+        $atom = new Atom();
+        $atom->setFeedElement(new Feed('id', 'test', new \DateTimeImmutable()));
+
+        $entry = new Entry('id', 'title', new \DateTimeImmutable());
+        $atom->addEntryElement($entry);
+
+        self::assertFalse(FeedValidator::hasRequiredAuthors($atom), 'Entry does not have an author. (No Feed Author)');
+
+        $entry->setAuthor(new Person('Jesse Rushlow'));
+
+        self::assertTrue(FeedValidator::hasRequiredAuthors($atom), 'Entry has an author. (No Feed Author)');
+
+        $atom->addEntryElement(new Entry('id', 'title', new \DateTimeImmutable()));
+
+        self::assertFalse(FeedValidator::hasRequiredAuthors($atom), 'Only 1 entry has an author. (No Feed Author)');
+    }
+}


### PR DESCRIPTION
The feed and entries can have an author(s) - let's be able to generate them as needed.

- AtomBuilder will enforce author validation by default. If validation fails, an exception will be thrown.

fixes #15 