### PR TITLE
improve person support

### DIFF
--- a/src/Collection/AbstractCollection.php
+++ b/src/Collection/AbstractCollection.php
@@ -23,6 +23,8 @@ use RushlowDevelopment\Atom\Contract\CollectionInterface;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  *
+ * @internal
+ *
  * @template T
  */
 abstract class AbstractCollection implements CollectionInterface

--- a/src/Collection/AbstractCollection.php
+++ b/src/Collection/AbstractCollection.php
@@ -22,9 +22,12 @@ use RushlowDevelopment\Atom\Contract\CollectionInterface;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @template T
  */
 abstract class AbstractCollection implements CollectionInterface
 {
+    /** @var T[] */
     protected array $elements = [];
 
     /**
@@ -38,7 +41,7 @@ abstract class AbstractCollection implements CollectionInterface
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->elements);
     }

--- a/src/Collection/PersonCollection.php
+++ b/src/Collection/PersonCollection.php
@@ -27,14 +27,18 @@ use RushlowDevelopment\Atom\Model\Person;
  */
 final class PersonCollection extends AbstractCollection
 {
-    public function addPerson(Person $person): void
+    public function addPerson(Person $person): self
     {
         $this->offsetSet($person->name, $person);
+
+        return $this;
     }
 
-    public function removePerson(Person $person): void
+    public function removePerson(Person $person): self
     {
         $this->offsetUnset($person->name);
+
+        return $this;
     }
 
     public function getPerson(string $name): Person

--- a/src/Collection/PersonCollection.php
+++ b/src/Collection/PersonCollection.php
@@ -20,16 +20,21 @@ namespace RushlowDevelopment\Atom\Collection;
 
 use RushlowDevelopment\Atom\Model\Person;
 
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @extends AbstractCollection<Person>
+ */
 final class PersonCollection extends AbstractCollection
 {
     public function addPerson(Person $person): void
     {
-        $this->offsetSet($person->getName(), $person);
+        $this->offsetSet($person->name, $person);
     }
 
     public function removePerson(Person $person): void
     {
-        $this->offsetUnset($person->getName());
+        $this->offsetUnset($person->name);
     }
 
     public function getPerson(string $name): Person

--- a/src/Generator/AtomXmlGenerator.php
+++ b/src/Generator/AtomXmlGenerator.php
@@ -20,6 +20,7 @@ namespace RushlowDevelopment\Atom\Generator;
 
 use RushlowDevelopment\Atom\Model\Entry;
 use RushlowDevelopment\Atom\Model\Feed;
+use RushlowDevelopment\Atom\Model\Person;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -66,9 +67,7 @@ final class AtomXmlGenerator
             }
 
             foreach ($feedModel->getAuthor() as $author) {
-                $authorElement = $this->document->createElement('author');
-                $authorElement->appendChild(new \DOMElement('name', $author->getName()));
-                $feedElement->appendChild($authorElement);
+                $feedElement->appendChild($this->createAuthorElement($author));
             }
         } catch (\DOMException $exception) {
             throw new \RuntimeException('Unable to build feed element.', previous: $exception);
@@ -105,9 +104,7 @@ final class AtomXmlGenerator
                 }
 
                 foreach ($entry->getAuthor() as $author) {
-                    $authorElement = $this->document->createElement('author');
-                    $authorElement->appendChild(new \DOMElement('name', $author->getName()));
-                    $node->appendChild($authorElement);
+                    $node->appendChild($this->createAuthorElement($author));
                 }
             } catch (\DOMException $exception) {
                 throw new \RuntimeException('Unable to build feed element.', previous: $exception);
@@ -115,5 +112,21 @@ final class AtomXmlGenerator
 
             $feed->appendChild($node);
         }
+    }
+
+    private function createAuthorElement(Person $person): \DOMElement
+    {
+        $authorElement = $this->document->createElement('author');
+        $authorElement->appendChild(new \DOMElement('name', $person->name));
+
+        if (null !== $person->uri) {
+            $authorElement->appendChild(new \DOMElement('uri', $person->uri));
+        }
+
+        if (null !== $person->email) {
+            $authorElement->appendChild(new \DOMElement('email', $person->email));
+        }
+
+        return $authorElement;
     }
 }

--- a/src/Model/Person.php
+++ b/src/Model/Person.php
@@ -21,38 +21,12 @@ namespace RushlowDevelopment\Atom\Model;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  */
-class Person
+final class Person
 {
-    private ?string $uri = null;
-    private ?string $email = null;
-
     public function __construct(
-        private string $name
+        public readonly string $name,
+        public readonly null|string $uri = null,
+        public readonly null|string $email = null,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function getUri(): ?string
-    {
-        return $this->uri;
-    }
-
-    public function setUri(string $uri): void
-    {
-        $this->uri = $uri;
-    }
-
-    public function getEmail(): ?string
-    {
-        return $this->email;
-    }
-
-    public function setEmail(string $email): void
-    {
-        $this->email = $email;
     }
 }

--- a/src/Model/Person.php
+++ b/src/Model/Person.php
@@ -19,10 +19,17 @@
 namespace RushlowDevelopment\Atom\Model;
 
 /**
+ * An RFC 4287 Complaint Person Construct Representation.
+ *
  * @author Jesse Rushlow <jr@rushlow.dev>
  */
 final class Person
 {
+    /**
+     * @param string      $name  a human-readable & language sensitive name for the person
+     * @param string|null $uri   the IRI for the person
+     * @param string|null $email the persons "addr-spec" (RFC2822) compliant email address
+     */
     public function __construct(
         public readonly string $name,
         public readonly null|string $uri = null,

--- a/tests/FunctionalTests/Fixture/expected/feed-all-author-fields.xml
+++ b/tests/FunctionalTests/Fixture/expected/feed-all-author-fields.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://rushlow.dev</id>
+  <title>Rushlow.dev XMLGenerator Test</title>
+  <updated>2023-01-17T23:00:00+00:00</updated>
+  <author>
+    <name>Jesse Rushlow</name>
+    <uri>https://rushlow.dev</uri>
+    <email>jr@rushlow.dev</email>
+  </author>
+  <entry>
+    <id>id</id>
+    <title>title</title>
+    <updated>2023-01-20T23:00:00+00:00</updated>
+    <author>
+      <name>Jesse Rushlow</name>
+      <uri>https://rushlow.dev</uri>
+      <email>jr@rushlow.dev</email>
+    </author>
+  </entry>
+</feed>

--- a/tests/FunctionalTests/Fixture/expected/feed-multiple-authors.xml
+++ b/tests/FunctionalTests/Fixture/expected/feed-multiple-authors.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://rushlow.dev</id>
+  <title>Rushlow.dev XMLGenerator Test</title>
+  <updated>2023-01-17T23:00:00+00:00</updated>
+  <author>
+    <name>Jesse Rushlow</name>
+    <uri>https://rushlow.dev</uri>
+    <email>jr@rushlow.dev</email>
+  </author>
+  <author>
+    <name>Someone Else</name>
+    <uri>https://their-domain.com</uri>
+    <email>not@my-email.com</email>
+  </author>
+  <entry>
+    <id>id</id>
+    <title>title</title>
+    <updated>2023-01-20T23:00:00+00:00</updated>
+    <author>
+      <name>Jesse Rushlow</name>
+      <uri>https://rushlow.dev</uri>
+      <email>jr@rushlow.dev</email>
+    </author>
+    <author>
+      <name>Someone Else</name>
+      <uri>https://their-domain.com</uri>
+      <email>not@my-email.com</email>
+    </author>
+  </entry>
+</feed>

--- a/tests/UnitTests/Model/PersonTest.php
+++ b/tests/UnitTests/Model/PersonTest.php
@@ -18,80 +18,28 @@
 
 namespace RushlowDevelopment\Atom\UnitTests\Model;
 
+use PHPUnit\Framework\TestCase;
 use RushlowDevelopment\Atom\Model\Person;
-use RushlowDevelopment\Atom\UnitTests\AbstractModelTest;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  *
  * @internal
  */
-final class PersonTest extends AbstractModelTest
+final class PersonTest extends TestCase
 {
-    protected function setUp(): void
+    public function testPersonHasRequiredProperties(): void
     {
-        $this->classUnderTest = Person::class;
+        $reflectedModel = new \ReflectionClass(Person::class);
+
+        self::assertTrue($reflectedModel->hasProperty('name'));
     }
 
-    public function requiredPropertyPerRFCDataProvider(): \Generator
+    public function testPersonHasOptionalProperties(): void
     {
-        yield 'Name property' => ['name'];
-    }
+        $reflectedModel = new \ReflectionClass(Person::class);
 
-    public function optionalPropertyPerRFCDataProvider(): \Generator
-    {
-        yield 'Email property' => ['email'];
-        yield 'Uri property' => ['uri'];
-    }
-
-    public function requiredMethodDataProvider(): array
-    {
-        return [
-            ['getName'],
-            ['getUri'],
-            ['setUri'],
-            ['getEmail'],
-            ['setEmail'],
-        ];
-    }
-
-    /**
-     * @dataProvider requiredMethodDataProvider
-     */
-    public function testAuthorHasRequiredMethods(string $methodName): void
-    {
-        self::assertTrue(method_exists(Person::class, $methodName));
-    }
-
-    public function testAllPropertiesAreInitializedWithConstructor(): void
-    {
-        $author = new Person('');
-
-        self::assertSame('', $author->getName());
-        self::assertNull($author->getUri());
-        self::assertNull($author->getEmail());
-    }
-
-    public function setterDataProvider(): array
-    {
-        return [
-            'Person Uri Setter Test' => [
-                'getUri', 'setUri', 'https://geeshoe.com',
-            ],
-            'Person Email Setter Test' => [
-                'getEmail', 'setEmail', 'jr@rushlow.dev',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider setterDataProvider
-     */
-    public function testAuthorSettersSetGivenParamToProperty(string $getter, string $setter, string $expected): void
-    {
-        $author = new Person('');
-
-        $author->$setter($expected);
-        self::assertSame($expected, $author->$getter());
+        self::assertTrue($reflectedModel->hasProperty('uri'));
+        self::assertTrue($reflectedModel->hasProperty('email'));
     }
 }


### PR DESCRIPTION
- `Person` is immutable. Getters/setters have been replaced with public readonly properties.
- `PersonCollection` tweaks for IDE type guessing.
- `atom:author` elements now contain `Person::uri` && `Person::email` if they exist.